### PR TITLE
fix(ci): Avoid building the project when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,6 @@ jobs:
 
       - name: Publish barretenberg-sys
         run: |
-          cargo publish --package barretenberg-sys
+          cargo publish --package barretenberg-sys --no-verify
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.BARRETENBERG_SYS_CRATES_IO_TOKEN }}


### PR DESCRIPTION
We don't need to spend 15+ minutes building bb to publish.