### PR TITLE
fix: Barretenberg renamed pedersen to pedersen_commitment

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -81,7 +81,7 @@ fn main() -> Result<()> {
             r#"
             #include <barretenberg/dsl/acir_proofs/c_bind.hpp>
             #include <barretenberg/crypto/blake2s/c_bind.hpp>
-            #include <barretenberg/crypto/pedersen/c_bind.hpp>
+            #include <barretenberg/crypto/pedersen_commitment/c_bind.hpp>
             #include <barretenberg/crypto/schnorr/c_bind.hpp>
             #include <barretenberg/ecc/curves/bn254/scalar_multiplication/c_bind.hpp>
             "#,

--- a/flake.lock
+++ b/flake.lock
@@ -10,15 +10,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1680810781,
-        "narHash": "sha256-2ctkV3EyHtog3caxbckTDUtJbMk/USdmF179Jvr0w40=",
+        "lastModified": 1681153256,
+        "narHash": "sha256-0rHyY0vDbCfziBwFcrVZS9GDjLbjSQyCvTZhdmVhzk0=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "3bc724d2163d29041bfa29a1e49625bab77289a2",
+        "rev": "ac2db15e26e4403df4154d6f3d4765060f456bf2",
         "type": "github"
       },
       "original": {
         "owner": "AztecProtocol",
+        "ref": "phated/generator-memory-oob",
         "repo": "barretenberg",
         "type": "github"
       }
@@ -78,12 +79,15 @@
       }
     },
     "flake-utils_2": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1680776469,
-        "narHash": "sha256-3CXUDK/3q/kieWtdsYpDOBJw3Gw4Af6x+2EiSnIkNQw=",
+        "lastModified": 1681037374,
+        "narHash": "sha256-XL6X3VGbEFJZDUouv2xpKg2Aljzu/etPLv5e1FPt1q0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "411e8764155aa9354dbcd6d5faaeb97e9e3dce24",
+        "rev": "033b9f258ca96a10e543d4442071f614dc3f8412",
         "type": "github"
       },
       "original": {
@@ -94,11 +98,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680665430,
-        "narHash": "sha256-MTVhTukwza1Jlq2gECITZPFnhROmylP2uv3O3cSqQCE=",
+        "lastModified": 1681091990,
+        "narHash": "sha256-ifIzhksUBZKp5WgCuoVhDY32qaEplXp7khzrB6zkaFc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5233fd2ba76a3accb5aaa999c00509a11fd0793c",
+        "rev": "ea96b4af6148114421fda90df33cf236ff5ecf1d",
         "type": "github"
       },
       "original": {
@@ -152,16 +156,31 @@
         ]
       },
       "locked": {
-        "lastModified": 1680747499,
-        "narHash": "sha256-E9rcxSTsqRqNd4SD+D/4aqm3qfFyVw0S9YseCks7h+c=",
+        "lastModified": 1681093076,
+        "narHash": "sha256-6uLZNeuP5jDDGlFkXgcoAxsJhTKy8yUTw25zdLHzdxE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8ad3b5ee01a2074b54274216ff2cf0ab844a7426",
+        "rev": "45c2ed9dd1397526dad35fc867c43955d87f9f3f",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     };
 
     barretenberg = {
-      url = "github:AztecProtocol/barretenberg";
+      url = "github:AztecProtocol/barretenberg/phated/generator-memory-oob";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";


### PR DESCRIPTION
Upstream bb introduced more breaking changes. This time they renamed the `pedersen` directory to `pedersen_commitment`.

Draft while we are pinned to a branch.