### PR TITLE
fix: Update barretenberg to version with mutex on pedersen generators

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           repository: AztecProtocol/barretenberg
           path: barretenberg
-          ref: d104756225a72c047a6b54d453cea2d3fb0110bb
+          ref: ecb61292c96c3b1fc673bcd96920cd2f00fe28b9
 
       - name: Setup Linux environment
         if: matrix.os == 'ubuntu-latest'
@@ -87,4 +87,4 @@ jobs:
 
       - name: Run cargo test
         run: |
-          cargo test --locked -- --test-threads=1
+          cargo test --locked

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ to install everything globally, you'll need:
 
     Linker provided by Clang, but might need to be installed via `apt install lld`.
 
-4. `barretenberg` (preferably at commit `d104756225a72c047a6b54d453cea2d3fb0110bb`)
+4. `barretenberg` (preferably at commit `ecb61292c96c3b1fc673bcd96920cd2f00fe28b9`)
 
     Needs to be built and installed following the instructions [in the README](https://github.com/AztecProtocol/barretenberg#getting-started). Note that barretenberg has its own [dependencies](https://github.com/AztecProtocol/barretenberg#dependencies) that will need to be installed, such as `cmake` and `ninja`.
 

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681402584,
-        "narHash": "sha256-AAfe7VTfHCRqBmxTW2dhHl58tZbJRa4zjU2X7kuKnzQ=",
+        "lastModified": 1682094239,
+        "narHash": "sha256-dJ+Ww1IxdI37XnWMDOJQbzOonzR/AQWJQfL2xkAc1Js=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "d104756225a72c047a6b54d453cea2d3fb0110bb",
+        "rev": "ecb61292c96c3b1fc673bcd96920cd2f00fe28b9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -71,13 +71,6 @@
       environment = {
         # rust-bindgen needs to know the location of libclang
         LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-
-        # Barretenberg fails if tests are run on multiple threads, so we set the test thread
-        # count to 1 throughout the entire project
-        #
-        # Note: Setting this allows for consistent behavior across build and shells, but is mostly
-        # hidden from the developer - i.e. when they see the command being run via `nix flake check`
-        RUST_TEST_THREADS = "1";
       };
 
       # As per https://discourse.nixos.org/t/gcc11stdenv-and-clang/17734/7 since it seems that aarch64-linux uses


### PR DESCRIPTION
Updates barretenberg to the latest commit, which adds a mutex around the init function for global generators.

This should allow us to remove the test_threads=1 limitation.