### PR TITLE
chore(ci): Switch to nix flake check command & rename jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   nix:
-    name: Nix build & test (${{ matrix.os }})
+    name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -30,16 +30,12 @@ jobs:
           nix_path: nixpkgs=channel:nixos-22.11
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cargo clippy
+      - name: Run `nix flake check`
         run: |
-          nix build -L .#checks.${{ matrix.target }}.cargo-clippy
-
-      - name: Cargo test
-        run: |
-          nix build -L .#checks.${{ matrix.target }}.cargo-test
+          nix flake check -L
 
   native:
-    name: Native build & test (${{ matrix.os }})
+    name: Test on ${{ matrix.os }} with global bb
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Closes #3

I've come around to the idea of using `nix flake check` in CI because we can add or update checks and it won't require changes to the workflows. This is really helpful for adding tests behind feature flags.