### PR TITLE
feat!: Recursion bindings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -80,6 +80,8 @@ fn main() -> Result<()> {
         .allowlist_function("acir_proofs_get_total_circuit_size")
         .allowlist_function("acir_proofs_init_proving_key")
         .allowlist_function("acir_proofs_init_verification_key")
+        .allowlist_function("acir_serialize_verification_key_into_field_elements")
+        .allowlist_function("acir_serialize_proof_into_field_elements")
         .allowlist_function("acir_proofs_new_proof")
         .allowlist_function("acir_proofs_verify_proof")
         .allowlist_function("pedersen_plookup_compress_fields")

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -48,6 +48,32 @@ pub unsafe fn init_verification_key(
     )
 }
 
+pub unsafe fn serialize_verification_key_into_field_elements(
+    g2_ptr: &[u8],
+    vk_buf: &[u8],
+    serialized_vk_buf: *mut *mut u8,
+    serialized_vk_hash_buf: *mut *mut u8,
+) -> usize {
+    acir_serialize_verification_key_into_field_elements(
+        g2_ptr.as_ptr() as *const u8,
+        vk_buf.as_ptr() as *const u8,
+        serialized_vk_buf as *const *mut u8 as *mut *mut u8,
+        serialized_vk_hash_buf as *const *mut u8 as *mut *mut u8,
+    )
+}
+
+pub unsafe fn serialize_proof_into_field_elements(
+    proof: &[u8],
+    serialized_proof_data_buf: *mut *mut u8,
+    proof_data_length: usize,
+) -> usize {
+    acir_serialize_proof_into_field_elements(
+        proof.as_ptr() as *const u8,
+        serialized_proof_data_buf,
+        proof_data_length,
+    )
+}
+
 /// # Safety
 /// pippenger must point to a valid Pippenger object
 pub unsafe fn create_proof_with_pk(
@@ -57,6 +83,7 @@ pub unsafe fn create_proof_with_pk(
     cs_ptr: &[u8],
     witness_ptr: &[u8],
     proof_data_ptr: *mut *mut u8,
+    is_recursive: bool,
 ) -> usize {
     let cs_ptr = cs_ptr.as_ptr() as *const u8;
     let pk_ptr = pk_ptr.as_ptr() as *const u8;
@@ -67,12 +94,19 @@ pub unsafe fn create_proof_with_pk(
         cs_ptr,
         witness_ptr.as_ptr(),
         proof_data_ptr as *const *mut u8 as *mut *mut u8,
+        is_recursive,
     )
 }
 
 /// # Safety
 /// cs_prt must point to a valid constraints system structure of type standard_format
-pub unsafe fn verify_with_vk(g2_ptr: &[u8], vk_ptr: &[u8], cs_ptr: &[u8], proof: &[u8]) -> bool {
+pub unsafe fn verify_with_vk(
+    g2_ptr: &[u8],
+    vk_ptr: &[u8],
+    cs_ptr: &[u8],
+    proof: &[u8],
+    is_recursive: bool,
+) -> bool {
     let proof_ptr = proof.as_ptr() as *const u8;
 
     acir_proofs_verify_proof(
@@ -81,5 +115,6 @@ pub unsafe fn verify_with_vk(g2_ptr: &[u8], vk_ptr: &[u8], cs_ptr: &[u8], proof:
         cs_ptr.as_ptr() as *const u8,
         proof_ptr as *mut u8,
         proof.len() as u32,
+        is_recursive,
     )
 }


### PR DESCRIPTION
The branch in this PR is being used locally: https://github.com/AztecProtocol/barretenberg/pull/379

You can build using `nix build . --override-input barretenberg github:AztecProtocol/barretenberg/mv/recursion-binds` inside the vscode direnv.

Or you can use a separate terminal to use `nix flake lock --override-input barretenberg github:AztecProtocol/barretenberg/mv/recursion-binds`