### PR TITLE
feat!: update bindings for pedersen with hash_index

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -84,7 +84,7 @@ fn main() -> Result<()> {
         .allowlist_function("acir_proofs_verify_proof")
         .allowlist_function("pedersen_plookup_compress_fields")
         .allowlist_function("pedersen_plookup_compress")
-        .allowlist_function("pedersen_plookup_commit")
+        .allowlist_function("pedersen_plookup_commit_with_hash_index")
         .allowlist_function("new_pippenger")
         .allowlist_function("compute_public_key")
         .allowlist_function("construct_signature")

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682094239,
-        "narHash": "sha256-dJ+Ww1IxdI37XnWMDOJQbzOonzR/AQWJQfL2xkAc1Js=",
+        "lastModified": 1683807808,
+        "narHash": "sha256-sqszqYkacS82dqvV8WM0U0KI/A/j6ZqxbiGx1JkZbpE=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "ecb61292c96c3b1fc673bcd96920cd2f00fe28b9",
+        "rev": "d5174e587754eaf5b1d17ebe51c12c2425195be8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683807808,
-        "narHash": "sha256-sqszqYkacS82dqvV8WM0U0KI/A/j6ZqxbiGx1JkZbpE=",
+        "lastModified": 1685366895,
+        "narHash": "sha256-SWWyCFRz3yjQiXdsGzByDplLMH3xe6d/Cs4O3bBDhAU=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "d5174e587754eaf5b1d17ebe51c12c2425195be8",
+        "rev": "97c3118e977d25b5a32ab30911634fe757117717",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685366895,
-        "narHash": "sha256-SWWyCFRz3yjQiXdsGzByDplLMH3xe6d/Cs4O3bBDhAU=",
+        "lastModified": 1685506002,
+        "narHash": "sha256-rspz4SY46kwqaS3R0IyTLadYN1trW1bcoDVrWg8MAmo=",
         "owner": "AztecProtocol",
         "repo": "barretenberg",
-        "rev": "97c3118e977d25b5a32ab30911634fe757117717",
+        "rev": "185b05c8f2a5eaedb54d569fabcfcd3c4b1d0823",
         "type": "github"
       },
       "original": {

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -32,7 +32,7 @@ pub fn compress_many(inputs: &[[u8; 32]]) -> [u8; 32] {
     result
 }
 
-pub fn encrypt(inputs_buffer: &[[u8; 32]]) -> ([u8; 32], [u8; 32]) {
+pub fn encrypt(inputs_buffer: &[[u8; 32]], hash_index: u32) -> ([u8; 32], [u8; 32]) {
     let mut buffer = Vec::new();
     let buffer_len = inputs_buffer.len() as u32;
     let mut result = [0_u8; 64];
@@ -42,7 +42,11 @@ pub fn encrypt(inputs_buffer: &[[u8; 32]]) -> ([u8; 32], [u8; 32]) {
     }
 
     unsafe {
-        pedersen_plookup_commit(buffer.as_ptr() as *const u8, result.as_mut_ptr());
+        pedersen_plookup_commit_with_hash_index(
+            buffer.as_ptr() as *const u8,
+            result.as_mut_ptr(),
+            hash_index,
+        );
     }
     let s: [u8; 32] = (result[0..32]).try_into().unwrap();
     let e: [u8; 32] = (result[32..64]).try_into().unwrap();
@@ -99,7 +103,7 @@ mod tests {
         f_one[31] = 1;
         let inputs: Vec<[u8; 32]> = vec![f_zero, f_one];
 
-        let (x, y) = encrypt(&inputs);
+        let (x, y) = encrypt(&inputs, 0);
         let expected_x = "11831f49876c313f2a9ec6d8d521c7ce0b6311c852117e340bfe27fd1ac096ef";
         let expected_y = "0ecf9d98be4597a88c46a7e0fa8836b57a7dcb41ee30f8d8787b11cc259c83fa";
         assert_eq!(expected_x, hex::encode(x));


### PR DESCRIPTION
Updated bb pointer, updated bindings for pedersen with hash_index, and updated the pedersen values due to the pedersen implementation change of https://github.com/AztecProtocol/barretenberg/pull/414/files#diff-3efc25f3b79f11be68c59e48ae56e83dbd6f38a4c0505e2e3f5ddb3297b7c520 that has been carried over with this pointer update